### PR TITLE
fix: check whether undefined first

### DIFF
--- a/src/RTLArabic.js
+++ b/src/RTLArabic.js
@@ -149,8 +149,8 @@ class RTLArabic extends String {
   #addEngChar(index) {
     // Add english letters, numbers, and symbols as is
     while (
-      !RTLArabic.isArabic(this.chars[index]) &&
-      this.chars[index] !== undefined
+      this.chars[index] !== undefined &&
+      !RTLArabic.isArabic(this.chars[index])
     ) {
       this.engStr += this.chars[index];
       index++;


### PR DESCRIPTION
A simple yet important fix.

As of now, the following throws an error:
```js
> new RTLarabic(`ولم يكن له كفوا احدۢ`).convert()
Uncaught TypeError: Cannot read properties of undefined (reading 'length')
    at RTLArabic.isArabic (/home/muhammad/github/create-qari/node_modules/rtl-arabic/src/RTLArabic.js:107:14)
    at #addEngChar (/home/muhammad/github/create-qari/node_modules/rtl-arabic/src/RTLArabic.js:152:18)
    at #runTests (/home/muhammad/github/create-qari/node_modules/rtl-arabic/src/RTLArabic.js:307:31)
    at RTLArabic.convert (/home/muhammad/github/create-qari/node_modules/rtl-arabic/src/RTLArabic.js:339:25)
```
<br>

After this fix, it seems perfect. Alhamdulillah.


![221220-085449](https://user-images.githubusercontent.com/50658760/208570910-adaf4691-c767-4ce3-8909-7886772b2633.png)
